### PR TITLE
fix: don't fail deserializing the document if CVSS can't be parsed

### DIFF
--- a/src/interop.rs
+++ b/src/interop.rs
@@ -189,8 +189,7 @@ pub mod rustsec {
                                     println!("INVALID Product ID");
                                     vec![ProductIdT("INVALID".to_string())]
                                 }),
-                            cvss_v2: None,
-                            cvss_v3: Some(b),
+                            cvss_scores: vec![b.into()],
                         }]
                     }),
                     threats: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,4 +102,39 @@ mod tests {
         let document: Csaf = serde_json_round_trip(example);
         println!("{:#?}", document);
     }
+
+    #[test]
+    fn cvss_example_deserializes() {
+        let example = include_str!("../tests/ssa-054046.json");
+        let document: Csaf = serde_json::from_str(example).expect("Failed to deserialize JSON");
+
+        // Check vulnerabilities
+        let vulns = document
+            .vulnerabilities
+            .as_ref()
+            .expect("Expected vulnerabilities to be present");
+        assert_eq!(vulns.len(), 1, "Expected exactly one vulnerability");
+
+        // Check scores
+        let scores = vulns[0]
+            .scores
+            .as_ref()
+            .expect("Expected scores to be present");
+        assert_eq!(scores.len(), 1, "Expected exactly one score");
+
+        // Check CVSS score
+        let cvss_scores = &scores[0].cvss_scores;
+        assert_eq!(cvss_scores.len(), 1, "Expected exactly one CVSS score");
+
+        // Verify baseSeverity
+        assert_eq!(
+            cvss_scores[0]
+                .raw
+                .get("baseSeverity")
+                .and_then(|v| v.as_str())
+                .expect("Expected baseSeverity to be present"),
+            "MEDIUM",
+            "Expected CVSS score baseSeverity to be MEDIUM"
+        );
+    }
 }

--- a/src/vulnerability.rs
+++ b/src/vulnerability.rs
@@ -1,6 +1,9 @@
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, TryFromInto};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Map;
+use serde_json::{json, Value};
+use serde_with::serde_as;
+use std::str::FromStr;
 use url::Url;
 
 use crate::definitions::{AcknowledgmentsT, NotesT, ProductGroupsT, ProductsT, ReferencesT};
@@ -161,72 +164,203 @@ pub enum RestartCategory {
 /// [Score](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#32312-vulnerabilities-property---scores)
 #[serde_as]
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Score {
     pub products: ProductsT,
-    // TODO: A CVSS v2 representation, or just document it as out of scope
-    // TODO: Should have at least one of:
-    pub cvss_v2: Option<serde_json::Value>,
-    #[serde_as(as = "Option<TryFromInto<cvss_json::Cvss3>>")]
-    pub cvss_v3: Option<cvss::v3::Base>,
+    // Collection of CVSS scores (raw and parsed)
+    pub cvss_scores: Vec<CvssScore>,
 }
 
-mod cvss_json {
-    use std::str::FromStr;
+#[derive(Debug, Clone, PartialEq)]
+pub struct CvssScore {
+    // CVSS version (e.g., 2.0, 3.0, 3.1, 4.0, or unknown)
+    pub version: CvssVersion,
+    // Raw JSON data for the CVSS score
+    pub raw: Value,
+    // Parsed CVSS score, if parsing was successful
+    pub parsed: Option<ParsedCvss>,
+}
 
-    use serde::{Deserialize, Serialize, Serializer};
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum CvssVersion {
+    #[serde(rename = "2.0")]
+    V2_0,
+    #[serde(rename = "3.0")]
+    V3_0,
+    #[serde(rename = "3.1")]
+    V3_1,
+    #[serde(untagged)]
+    Unknown(String),
+}
 
-    /// CVSSv3 JSON Representation
-    ///
-    /// An internal representation of a CVSS score, meant to be serializable to JSON as specified in
-    /// [https://www.first.org/cvss/cvss-v3.1.json](https://www.first.org/cvss/cvss-v3.1.json).
-    ///
-    /// Use with [cvss::v3::Base] and the provided `From` implementation.
-    #[derive(Serialize, Deserialize, Debug, Clone)]
-    #[serde(rename_all = "camelCase")]
-    pub(crate) struct Cvss3 {
-        // TODO: Should be able to store just the Base and generate the rest of this at serialize time?
-        version: Cvss3Version,
-        vector_string: String,
-        base_score: f64,
-        #[serde(serialize_with = "severity_to_upper")]
-        base_severity: cvss::Severity,
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum ParsedCvss {
+    V3(cvss::v3::Base), // Parsed CVSS v3 (3.0 or 3.1)
+}
+
+impl From<cvss::v3::Base> for CvssScore {
+    fn from(base: cvss::v3::Base) -> Self {
+        // Attempt to serialize the base back to JSON (used for raw)
+        let raw = serde_json::to_value(&base).unwrap_or(Value::Null);
+
+        // Detect version from vector string
+        let version = match base.minor_version {
+            0 => CvssVersion::V3_0,
+            1 => CvssVersion::V3_1,
+            _ => CvssVersion::Unknown(format!("3.{}", base.minor_version)),
+        };
+
+        CvssScore {
+            version,
+            raw,
+            parsed: Some(ParsedCvss::V3(base)),
+        }
     }
+}
 
-    // https://www.first.org/cvss/cvss-v3.1.json requires baseSeverity field to be uppercase.
-    // cvss crate normalizes to lowercase.
-    fn severity_to_upper<S>(severity: &cvss::Severity, serializer: S) -> Result<S::Ok, S::Error>
+pub fn cvss_base_to_json(base: &cvss::v3::Base) -> Value {
+    let version_str = match base.minor_version {
+        0 => "3.0",
+        1 => "3.1",
+        _ => &format!("3.{}", base.minor_version),
+    };
+
+    json!({
+        "version": version_str,
+        "vectorString": base.to_string(),
+        "baseScore": base.score().value(),
+        "baseSeverity": base.severity().as_str().to_uppercase(),
+    })
+}
+
+impl<'de> Deserialize<'de> for Score {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawScore {
+            products: ProductsT,
+            #[serde(default)]
+            cvss_v2: Option<Value>,
+            #[serde(default)]
+            cvss_v3: Option<Value>,
+        }
+
+        let raw_score = RawScore::deserialize(deserializer)?;
+        let mut cvss_scores = Vec::new();
+        let keep_fields = ["version", "vectorString", "baseScore", "baseSeverity"];
+
+        // Helper function to filter fields
+        fn filter_fields(value: &Value, keys: &[&str]) -> Value {
+            let mut filtered = Map::new();
+            if let Value::Object(obj) = value {
+                for &key in keys {
+                    if let Some(val) = obj.get(key) {
+                        filtered.insert(key.to_string(), val.clone());
+                    }
+                }
+            }
+            Value::Object(filtered)
+        }
+
+        // Process cvss_v2 if present
+        if let Some(v2) = raw_score.cvss_v2 {
+            let version = v2
+                .get("version")
+                .and_then(|v| v.as_str())
+                .map(|v| match v {
+                    "2.0" => CvssVersion::V2_0,
+                    other => CvssVersion::Unknown(other.to_string()),
+                })
+                .unwrap_or(CvssVersion::Unknown(String::new()));
+            cvss_scores.push(CvssScore {
+                version,
+                raw: filter_fields(&v2, &keep_fields),
+                parsed: None, // CVSS v2 not parsed
+            });
+        }
+
+        // Process cvss_v3 if present
+        if let Some(v3) = raw_score.cvss_v3 {
+            let version = v3
+                .get("version")
+                .and_then(|v| v.as_str())
+                .map(|v| match v {
+                    "3.0" => CvssVersion::V3_0,
+                    "3.1" => CvssVersion::V3_1,
+                    other => CvssVersion::Unknown(other.to_string()),
+                })
+                .unwrap_or(CvssVersion::Unknown(String::new()));
+            let parsed = match version {
+                CvssVersion::V3_0 | CvssVersion::V3_1 => {
+                    match v3.get("vectorString").and_then(|v| v.as_str()) {
+                        Some(vector) => match cvss::v3::Base::from_str(vector) {
+                            Ok(base) => Some(ParsedCvss::V3(base)),
+                            Err(_) => None, // Parsing failed
+                        },
+                        None => None, // Invalid JSON structure
+                    }
+                }
+                _ => None, // Unsupported version
+            };
+            cvss_scores.push(CvssScore {
+                version,
+                raw: filter_fields(&v3, &keep_fields),
+                parsed,
+            });
+        }
+
+        Ok(Score {
+            products: raw_score.products,
+            cvss_scores,
+        })
+    }
+}
+
+impl Serialize for Score {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        serializer.serialize_str(&severity.as_str().to_uppercase())
-    }
+        #[derive(Serialize)]
+        struct RawScore<'a> {
+            products: &'a ProductsT,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            cvss_v2: Option<&'a Value>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            cvss_v3: Option<Value>,
+        }
 
-    impl From<cvss::v3::Base> for Cvss3 {
-        fn from(b: cvss::v3::Base) -> Self {
-            Self {
-                version: Cvss3Version::ThreeDotOne,
-                vector_string: format!("{b}"),
-                base_score: b.score().value(),
-                base_severity: b.severity(),
+        let mut cvss_v2 = None;
+        let mut cvss_v3 = None;
+
+        // Select the first CvssScore for each version
+        for score in &self.cvss_scores {
+            match score.version {
+                CvssVersion::V2_0 | CvssVersion::Unknown(_) => {
+                    if cvss_v2.is_none() {
+                        cvss_v2 = Some(&score.raw);
+                    }
+                }
+                CvssVersion::V3_0 | CvssVersion::V3_1 => {
+                    if cvss_v3.is_none() {
+                        cvss_v3 = Some(match &score.parsed {
+                            Some(ParsedCvss::V3(base)) => cvss_base_to_json(base),
+                            None => score.raw.clone(),
+                        });
+                    }
+                }
             }
         }
-    }
 
-    impl TryFrom<Cvss3> for cvss::v3::Base {
-        type Error = <cvss::v3::Base as FromStr>::Err;
-
-        fn try_from(b: Cvss3) -> Result<Self, Self::Error> {
-            cvss::v3::Base::from_str(&b.vector_string)
+        RawScore {
+            products: &self.products,
+            cvss_v2,
+            cvss_v3,
         }
-    }
-
-    #[derive(Serialize, Deserialize, Debug, Clone)]
-    enum Cvss3Version {
-        #[serde(rename = "3.1")]
-        ThreeDotOne,
-        #[serde(rename = "3.0")]
-        ThreeDotZero,
+        .serialize(serializer)
     }
 }
 

--- a/tests/ssa-054046.json
+++ b/tests/ssa-054046.json
@@ -1,0 +1,3147 @@
+{
+    "document": {
+      "category": "csaf_security_advisory",
+      "csaf_version": "2.0",
+      "distribution": {
+        "text": "Disclosure is not limited. (TLPv2: TLP:CLEAR)",
+        "tlp": {
+          "label": "WHITE"
+        }
+      },
+      "lang": "en",
+      "notes": [
+        {
+          "category": "summary",
+          "text": "Several SIMATIC S7-1500 CPU versions are affected by an authentication bypass vulnerability that could allow an unauthenticated remote attacker to gain knowledge about actual and configured maximum cycle times and communication load of the CPU.\n\nSiemens has released new versions for several affected products and recommends to update to the latest versions. Siemens is preparing further fix versions and recommends countermeasures for products where fixes are not, or not yet available.",
+          "title": "Summary"
+        },
+        {
+          "category": "general",
+          "text": "As a general security measure, Siemens strongly recommends to protect network access to devices with appropriate mechanisms. In order to operate the devices in a protected IT environment, Siemens recommends to configure the environment according to Siemens' operational guidelines for Industrial Security (Download: \nhttps://www.siemens.com/cert/operational-guidelines-industrial-security), and to follow the recommendations in the product manuals.\nAdditional information on Industrial Security by Siemens can be found at: https://www.siemens.com/industrialsecurity",
+          "title": "General Recommendations"
+        },
+        {
+          "category": "general",
+          "text": "For further inquiries on security vulnerabilities in Siemens products and solutions, please contact the Siemens ProductCERT: https://www.siemens.com/cert/advisories",
+          "title": "Additional Resources"
+        },
+        {
+          "category": "legal_disclaimer",
+          "text": "The use of Siemens Security Advisories is subject to the terms and conditions listed on: https://www.siemens.com/productcert/terms-of-use.",
+          "title": "Terms of Use"
+        }
+      ],
+      "publisher": {
+        "category": "vendor",
+        "contact_details": "productcert@siemens.com",
+        "name": "Siemens ProductCERT",
+        "namespace": "https://www.siemens.com"
+      },
+      "references": [
+        {
+          "category": "self",
+          "summary": "SSA-054046: Unauthenticated Information Disclosure in Web Server of SIMATIC S7-1500 CPUs - HTML Version",
+          "url": "https://cert-portal.siemens.com/productcert/html/ssa-054046.html"
+        },
+        {
+          "category": "self",
+          "summary": "SSA-054046: Unauthenticated Information Disclosure in Web Server of SIMATIC S7-1500 CPUs - CSAF Version",
+          "url": "https://cert-portal.siemens.com/productcert/csaf/ssa-054046.json"
+        }
+      ],
+      "title": "SSA-054046: Unauthenticated Information Disclosure in Web Server of SIMATIC S7-1500 CPUs",
+      "tracking": {
+        "current_release_date": "2025-04-08T00:00:00Z",
+        "generator": {
+          "engine": {
+            "name": "Siemens ProductCERT CSAF Generator",
+            "version": "1"
+          }
+        },
+        "id": "SSA-054046",
+        "initial_release_date": "2024-10-08T00:00:00Z",
+        "revision_history": [
+          {
+            "date": "2024-10-08T00:00:00Z",
+            "legacy_version": "1.0",
+            "number": "1",
+            "summary": "Publication Date"
+          },
+          {
+            "date": "2024-11-12T00:00:00Z",
+            "legacy_version": "1.1",
+            "number": "2",
+            "summary": "Added fix for SIMATIC S7-1500 CPU 1518-4 PN/DP MFP, CPU 1518-4 PN/DP MFP, CPU 1518F-4 PN/DP MFP, CPU 1518F-4 PN/DP MFP and CPU 1518-4 PN/DP MFP"
+          },
+          {
+            "date": "2025-01-14T00:00:00Z",
+            "legacy_version": "1.2",
+            "number": "3",
+            "summary": "Added fix for SIMATIC S7-PLCSIM Advanced"
+          },
+          {
+            "date": "2025-03-11T00:00:00Z",
+            "legacy_version": "1.3",
+            "number": "4",
+            "summary": "Added fix for SIMATIC ET 200SP Open Controller CPU 1515SP PC2 (incl. SIPLUS variants)"
+          },
+          {
+            "date": "2025-04-08T00:00:00Z",
+            "legacy_version": "1.4",
+            "number": "5",
+            "summary": "Added fix for SIMATIC S7-1500 Software Controller V3 and updated several product names"
+          }
+        ],
+        "status": "interim",
+        "version": "5"
+      }
+    },
+    "product_tree": {
+      "branches": [
+        {
+          "branches": [
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC Drive Controller CPU 1504D TF (6ES7615-4DF10-0AB0)",
+                    "product_id": "1",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7615-4DF10-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC Drive Controller CPU 1504D TF (6ES7615-4DF10-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC Drive Controller CPU 1507D TF (6ES7615-7DF10-0AB0)",
+                    "product_id": "2",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7615-7DF10-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC Drive Controller CPU 1507D TF (6ES7615-7DF10-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC ET 200SP CPU 1510SP F-1 PN (6ES7510-1SJ01-0AB0)",
+                    "product_id": "3",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7510-1SJ01-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC ET 200SP CPU 1510SP F-1 PN (6ES7510-1SJ01-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC ET 200SP CPU 1510SP F-1 PN (6ES7510-1SK03-0AB0)",
+                    "product_id": "4",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7510-1SK03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC ET 200SP CPU 1510SP F-1 PN (6ES7510-1SK03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC ET 200SP CPU 1510SP-1 PN (6ES7510-1DJ01-0AB0)",
+                    "product_id": "5",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7510-1DJ01-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC ET 200SP CPU 1510SP-1 PN (6ES7510-1DJ01-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC ET 200SP CPU 1510SP-1 PN (6ES7510-1DK03-0AB0)",
+                    "product_id": "6",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7510-1DK03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC ET 200SP CPU 1510SP-1 PN (6ES7510-1DK03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC ET 200SP CPU 1512SP F-1 PN (6ES7512-1SK01-0AB0)",
+                    "product_id": "7",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7512-1SK01-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC ET 200SP CPU 1512SP F-1 PN (6ES7512-1SK01-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC ET 200SP CPU 1512SP F-1 PN (6ES7512-1SM03-0AB0)",
+                    "product_id": "8",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7512-1SM03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC ET 200SP CPU 1512SP F-1 PN (6ES7512-1SM03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC ET 200SP CPU 1512SP-1 PN (6ES7512-1DK01-0AB0)",
+                    "product_id": "9",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7512-1DK01-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC ET 200SP CPU 1512SP-1 PN (6ES7512-1DK01-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC ET 200SP CPU 1512SP-1 PN (6ES7512-1DM03-0AB0)",
+                    "product_id": "10",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7512-1DM03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC ET 200SP CPU 1512SP-1 PN (6ES7512-1DM03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC ET 200SP CPU 1514SP F-2 PN (6ES7514-2SN03-0AB0)",
+                    "product_id": "11",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7514-2SN03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC ET 200SP CPU 1514SP F-2 PN (6ES7514-2SN03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC ET 200SP CPU 1514SP-2 PN (6ES7514-2DN03-0AB0)",
+                    "product_id": "12",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7514-2DN03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC ET 200SP CPU 1514SP-2 PN (6ES7514-2DN03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC ET 200SP CPU 1514SPT F-2 PN (6ES7514-2WN03-0AB0)",
+                    "product_id": "13",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7514-2WN03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC ET 200SP CPU 1514SPT F-2 PN (6ES7514-2WN03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC ET 200SP CPU 1514SPT-2 PN (6ES7514-2VN03-0AB0)",
+                    "product_id": "14",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7514-2VN03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC ET 200SP CPU 1514SPT-2 PN (6ES7514-2VN03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V31.1.4",
+                  "product": {
+                    "name": "SIMATIC ET 200SP Open Controller CPU 1515SP PC2 (incl. SIPLUS variants)",
+                    "product_id": "15"
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC ET 200SP Open Controller CPU 1515SP PC2 (incl. SIPLUS variants)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1511-1 PN (6ES7511-1AK01-0AB0)",
+                    "product_id": "16",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7511-1AK01-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1511-1 PN (6ES7511-1AK01-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1511-1 PN (6ES7511-1AK02-0AB0)",
+                    "product_id": "17",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7511-1AK02-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1511-1 PN (6ES7511-1AK02-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1511-1 PN (6ES7511-1AL03-0AB0)",
+                    "product_id": "18",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7511-1AL03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1511-1 PN (6ES7511-1AL03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1511C-1 PN (6ES7511-1CK00-0AB0)",
+                    "product_id": "19",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7511-1CK00-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1511C-1 PN (6ES7511-1CK00-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1511C-1 PN (6ES7511-1CK01-0AB0)",
+                    "product_id": "20",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7511-1CK01-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1511C-1 PN (6ES7511-1CK01-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1511C-1 PN (6ES7511-1CL03-0AB0)",
+                    "product_id": "21",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7511-1CL03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1511C-1 PN (6ES7511-1CL03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1511F-1 PN (6ES7511-1FK01-0AB0)",
+                    "product_id": "22",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7511-1FK01-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1511F-1 PN (6ES7511-1FK01-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1511F-1 PN (6ES7511-1FK02-0AB0)",
+                    "product_id": "23",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7511-1FK02-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1511F-1 PN (6ES7511-1FK02-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1511F-1 PN (6ES7511-1FL03-0AB0)",
+                    "product_id": "24",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7511-1FL03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1511F-1 PN (6ES7511-1FL03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1511T-1 PN (6ES7511-1TK01-0AB0)",
+                    "product_id": "25",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7511-1TK01-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1511T-1 PN (6ES7511-1TK01-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1511T-1 PN (6ES7511-1TL03-0AB0)",
+                    "product_id": "26",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7511-1TL03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1511T-1 PN (6ES7511-1TL03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1511TF-1 PN (6ES7511-1UK01-0AB0)",
+                    "product_id": "27",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7511-1UK01-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1511TF-1 PN (6ES7511-1UK01-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1511TF-1 PN (6ES7511-1UL03-0AB0)",
+                    "product_id": "28",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7511-1UL03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1511TF-1 PN (6ES7511-1UL03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1512C-1 PN (6ES7512-1CK00-0AB0)",
+                    "product_id": "29",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7512-1CK00-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1512C-1 PN (6ES7512-1CK00-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1512C-1 PN (6ES7512-1CK01-0AB0)",
+                    "product_id": "30",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7512-1CK01-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1512C-1 PN (6ES7512-1CK01-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1512C-1 PN (6ES7512-1CM03-0AB0)",
+                    "product_id": "31",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7512-1CM03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1512C-1 PN (6ES7512-1CM03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1513-1 PN (6ES7513-1AL01-0AB0)",
+                    "product_id": "32",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7513-1AL01-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1513-1 PN (6ES7513-1AL01-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1513-1 PN (6ES7513-1AL02-0AB0)",
+                    "product_id": "33",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7513-1AL02-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1513-1 PN (6ES7513-1AL02-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1513-1 PN (6ES7513-1AM03-0AB0)",
+                    "product_id": "34",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7513-1AM03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1513-1 PN (6ES7513-1AM03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1513F-1 PN (6ES7513-1FL01-0AB0)",
+                    "product_id": "35",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7513-1FL01-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1513F-1 PN (6ES7513-1FL01-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1513F-1 PN (6ES7513-1FL02-0AB0)",
+                    "product_id": "36",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7513-1FL02-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1513F-1 PN (6ES7513-1FL02-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1513F-1 PN (6ES7513-1FM03-0AB0)",
+                    "product_id": "37",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7513-1FM03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1513F-1 PN (6ES7513-1FM03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1513pro F-2 PN (6ES7513-2GM03-0AB0)",
+                    "product_id": "38",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7513-2GM03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1513pro F-2 PN (6ES7513-2GM03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1513pro-2 PN (6ES7513-2PM03-0AB0)",
+                    "product_id": "39",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7513-2PM03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1513pro-2 PN (6ES7513-2PM03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1515-2 PN (6ES7515-2AM01-0AB0)",
+                    "product_id": "40",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7515-2AM01-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1515-2 PN (6ES7515-2AM01-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1515-2 PN (6ES7515-2AM02-0AB0)",
+                    "product_id": "41",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7515-2AM02-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1515-2 PN (6ES7515-2AM02-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1515-2 PN (6ES7515-2AN03-0AB0)",
+                    "product_id": "42",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7515-2AN03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1515-2 PN (6ES7515-2AN03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1515F-2 PN (6ES7515-2FM01-0AB0)",
+                    "product_id": "43",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7515-2FM01-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1515F-2 PN (6ES7515-2FM01-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1515F-2 PN (6ES7515-2FM02-0AB0)",
+                    "product_id": "44",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7515-2FM02-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1515F-2 PN (6ES7515-2FM02-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1515F-2 PN (6ES7515-2FN03-0AB0)",
+                    "product_id": "45",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7515-2FN03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1515F-2 PN (6ES7515-2FN03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1515T-2 PN (6ES7515-2TM01-0AB0)",
+                    "product_id": "46",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7515-2TM01-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1515T-2 PN (6ES7515-2TM01-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1515T-2 PN (6ES7515-2TN03-0AB0)",
+                    "product_id": "47",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7515-2TN03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1515T-2 PN (6ES7515-2TN03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1515TF-2 PN (6ES7515-2UM01-0AB0)",
+                    "product_id": "48",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7515-2UM01-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1515TF-2 PN (6ES7515-2UM01-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1515TF-2 PN (6ES7515-2UN03-0AB0)",
+                    "product_id": "49",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7515-2UN03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1515TF-2 PN (6ES7515-2UN03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1516-3 PN/DP (6ES7516-3AN01-0AB0)",
+                    "product_id": "50",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7516-3AN01-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1516-3 PN/DP (6ES7516-3AN01-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1516-3 PN/DP (6ES7516-3AN02-0AB0)",
+                    "product_id": "51",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7516-3AN02-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1516-3 PN/DP (6ES7516-3AN02-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1516-3 PN/DP (6ES7516-3AP03-0AB0)",
+                    "product_id": "52",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7516-3AP03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1516-3 PN/DP (6ES7516-3AP03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1516F-3 PN/DP (6ES7516-3FN01-0AB0)",
+                    "product_id": "53",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7516-3FN01-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1516F-3 PN/DP (6ES7516-3FN01-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1516F-3 PN/DP (6ES7516-3FN02-0AB0)",
+                    "product_id": "54",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7516-3FN02-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1516F-3 PN/DP (6ES7516-3FN02-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1516F-3 PN/DP (6ES7516-3FP03-0AB0)",
+                    "product_id": "55",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7516-3FP03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1516F-3 PN/DP (6ES7516-3FP03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1516pro F-2 PN (6ES7516-2GP03-0AB0)",
+                    "product_id": "56",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7516-2GP03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1516pro F-2 PN (6ES7516-2GP03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1516pro-2 PN (6ES7516-2PP03-0AB0)",
+                    "product_id": "57",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7516-2PP03-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1516pro-2 PN (6ES7516-2PP03-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1516T-3 PN/DP (6ES7516-3TN00-0AB0)",
+                    "product_id": "58",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7516-3TN00-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1516T-3 PN/DP (6ES7516-3TN00-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1516TF-3 PN/DP (6ES7516-3UN00-0AB0)",
+                    "product_id": "59",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7516-3UN00-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1516TF-3 PN/DP (6ES7516-3UN00-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1517-3 PN/DP (6ES7517-3AP00-0AB0)",
+                    "product_id": "60",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7517-3AP00-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1517-3 PN/DP (6ES7517-3AP00-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1517F-3 PN/DP (6ES7517-3FP00-0AB0)",
+                    "product_id": "61",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7517-3FP00-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1517F-3 PN/DP (6ES7517-3FP00-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1517F-3 PN/DP (6ES7517-3FP01-0AB0)",
+                    "product_id": "62",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7517-3FP01-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1517F-3 PN/DP (6ES7517-3FP01-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1517T-3 PN/DP (6ES7517-3TP00-0AB0)",
+                    "product_id": "63",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7517-3TP00-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1517T-3 PN/DP (6ES7517-3TP00-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1517TF-3 PN/DP (6ES7517-3UP00-0AB0)",
+                    "product_id": "64",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7517-3UP00-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1517TF-3 PN/DP (6ES7517-3UP00-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1518-4 PN/DP (6ES7518-4AP00-0AB0)",
+                    "product_id": "65",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7518-4AP00-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1518-4 PN/DP (6ES7518-4AP00-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1518-4 PN/DP MFP (6ES7518-4AX00-1AB0)",
+                    "product_id": "66",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7518-4AX00-1AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1518-4 PN/DP MFP (6ES7518-4AX00-1AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1518-4 PN/DP MFP (6ES7518-4AX00-1AC0)",
+                    "product_id": "67",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7518-4AX00-1AC0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1518-4 PN/DP MFP (6ES7518-4AX00-1AC0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1518F-4 PN/DP (6ES7518-4FP00-0AB0)",
+                    "product_id": "68",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7518-4FP00-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1518F-4 PN/DP (6ES7518-4FP00-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1518F-4 PN/DP MFP (6ES7518-4FX00-1AB0)",
+                    "product_id": "69",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7518-4FX00-1AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1518F-4 PN/DP MFP (6ES7518-4FX00-1AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1518F-4 PN/DP MFP (6ES7518-4FX00-1AC0)",
+                    "product_id": "70",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7518-4FX00-1AC0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1518F-4 PN/DP MFP (6ES7518-4FX00-1AC0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1518T-4 PN/DP (6ES7518-4TP00-0AB0)",
+                    "product_id": "71",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7518-4TP00-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1518T-4 PN/DP (6ES7518-4TP00-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU 1518TF-4 PN/DP (6ES7518-4UP00-0AB0)",
+                    "product_id": "72",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7518-4UP00-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU 1518TF-4 PN/DP (6ES7518-4UP00-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU S7-1518-4 PN/DP ODK (6ES7518-4AP00-3AB0)",
+                    "product_id": "73",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7518-4AP00-3AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU S7-1518-4 PN/DP ODK (6ES7518-4AP00-3AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 CPU S7-1518F-4 PN/DP ODK (6ES7518-4FP00-3AB0)",
+                    "product_id": "74",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7518-4FP00-3AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 CPU S7-1518F-4 PN/DP ODK (6ES7518-4FP00-3AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 ET 200pro: CPU 1513PRO F-2 PN (6ES7513-2GL00-0AB0)",
+                    "product_id": "75",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7513-2GL00-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 ET 200pro: CPU 1513PRO F-2 PN (6ES7513-2GL00-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 ET 200pro: CPU 1513PRO-2 PN (6ES7513-2PL00-0AB0)",
+                    "product_id": "76",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7513-2PL00-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 ET 200pro: CPU 1513PRO-2 PN (6ES7513-2PL00-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 ET 200pro: CPU 1516PRO F-2 PN (6ES7516-2GN00-0AB0)",
+                    "product_id": "77",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7516-2GN00-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 ET 200pro: CPU 1516PRO F-2 PN (6ES7516-2GN00-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 ET 200pro: CPU 1516PRO-2 PN (6ES7516-2PN00-0AB0)",
+                    "product_id": "78",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6ES7516-2PN00-0AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 ET 200pro: CPU 1516PRO-2 PN (6ES7516-2PN00-0AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 Software Controller CPU 1507S F V2",
+                    "product_id": "79"
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 Software Controller CPU 1507S F V2"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V31.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 Software Controller CPU 1507S F V3",
+                    "product_id": "80"
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 Software Controller CPU 1507S F V3"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 Software Controller CPU 1507S V2",
+                    "product_id": "81"
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 Software Controller CPU 1507S V2"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V31.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 Software Controller CPU 1507S V3",
+                    "product_id": "82"
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 Software Controller CPU 1507S V3"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 Software Controller CPU 1508S F V2",
+                    "product_id": "83"
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 Software Controller CPU 1508S F V2"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V31.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 Software Controller CPU 1508S F V3",
+                    "product_id": "84"
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 Software Controller CPU 1508S F V3"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V31.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 Software Controller CPU 1508S T V3",
+                    "product_id": "85"
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 Software Controller CPU 1508S T V3"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V31.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 Software Controller CPU 1508S TF V3",
+                    "product_id": "86"
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 Software Controller CPU 1508S TF V3"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 Software Controller CPU 1508S V2",
+                    "product_id": "87"
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 Software Controller CPU 1508S V2"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V31.1.4",
+                  "product": {
+                    "name": "SIMATIC S7-1500 Software Controller CPU 1508S V3",
+                    "product_id": "88"
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 Software Controller CPU 1508S V3"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 Software Controller Linux V2",
+                    "product_id": "89"
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 Software Controller Linux V2"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIMATIC S7-1500 Software Controller Linux V3",
+                    "product_id": "90"
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-1500 Software Controller Linux V3"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V7.0",
+                  "product": {
+                    "name": "SIMATIC S7-PLCSIM Advanced",
+                    "product_id": "91"
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIMATIC S7-PLCSIM Advanced"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS ET 200SP CPU 1510SP F-1 PN (6AG1510-1SJ01-2AB0)",
+                    "product_id": "92",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1510-1SJ01-2AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS ET 200SP CPU 1510SP F-1 PN (6AG1510-1SJ01-2AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS ET 200SP CPU 1510SP F-1 PN RAIL (6AG2510-1SJ01-1AB0)",
+                    "product_id": "93",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG2510-1SJ01-1AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS ET 200SP CPU 1510SP F-1 PN RAIL (6AG2510-1SJ01-1AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS ET 200SP CPU 1510SP-1 PN (6AG1510-1DJ01-2AB0)",
+                    "product_id": "94",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1510-1DJ01-2AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS ET 200SP CPU 1510SP-1 PN (6AG1510-1DJ01-2AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS ET 200SP CPU 1510SP-1 PN (6AG1510-1DJ01-7AB0)",
+                    "product_id": "95",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1510-1DJ01-7AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS ET 200SP CPU 1510SP-1 PN (6AG1510-1DJ01-7AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS ET 200SP CPU 1510SP-1 PN RAIL (6AG2510-1DJ01-1AB0)",
+                    "product_id": "96",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG2510-1DJ01-1AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS ET 200SP CPU 1510SP-1 PN RAIL (6AG2510-1DJ01-1AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS ET 200SP CPU 1510SP-1 PN RAIL (6AG2510-1DJ01-4AB0)",
+                    "product_id": "97",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG2510-1DJ01-4AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS ET 200SP CPU 1510SP-1 PN RAIL (6AG2510-1DJ01-4AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS ET 200SP CPU 1512SP F-1 PN (6AG1512-1SK01-2AB0)",
+                    "product_id": "98",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1512-1SK01-2AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS ET 200SP CPU 1512SP F-1 PN (6AG1512-1SK01-2AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS ET 200SP CPU 1512SP F-1 PN (6AG1512-1SK01-7AB0)",
+                    "product_id": "99",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1512-1SK01-7AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS ET 200SP CPU 1512SP F-1 PN (6AG1512-1SK01-7AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS ET 200SP CPU 1512SP F-1 PN RAIL (6AG2512-1SK01-1AB0)",
+                    "product_id": "100",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG2512-1SK01-1AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS ET 200SP CPU 1512SP F-1 PN RAIL (6AG2512-1SK01-1AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS ET 200SP CPU 1512SP F-1 PN RAIL (6AG2512-1SK01-4AB0)",
+                    "product_id": "101",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG2512-1SK01-4AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS ET 200SP CPU 1512SP F-1 PN RAIL (6AG2512-1SK01-4AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS ET 200SP CPU 1512SP-1 PN (6AG1512-1DK01-2AB0)",
+                    "product_id": "102",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1512-1DK01-2AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS ET 200SP CPU 1512SP-1 PN (6AG1512-1DK01-2AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS ET 200SP CPU 1512SP-1 PN (6AG1512-1DK01-7AB0)",
+                    "product_id": "103",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1512-1DK01-7AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS ET 200SP CPU 1512SP-1 PN (6AG1512-1DK01-7AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS ET 200SP CPU 1512SP-1 PN RAIL (6AG2512-1DK01-1AB0)",
+                    "product_id": "104",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG2512-1DK01-1AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS ET 200SP CPU 1512SP-1 PN RAIL (6AG2512-1DK01-1AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS ET 200SP CPU 1512SP-1 PN RAIL (6AG2512-1DK01-4AB0)",
+                    "product_id": "105",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG2512-1DK01-4AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS ET 200SP CPU 1512SP-1 PN RAIL (6AG2512-1DK01-4AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1511-1 PN (6AG1511-1AK01-2AB0)",
+                    "product_id": "106",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1511-1AK01-2AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1511-1 PN (6AG1511-1AK01-2AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1511-1 PN (6AG1511-1AK01-7AB0)",
+                    "product_id": "107",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1511-1AK01-7AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1511-1 PN (6AG1511-1AK01-7AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1511-1 PN (6AG1511-1AK02-2AB0)",
+                    "product_id": "108",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1511-1AK02-2AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1511-1 PN (6AG1511-1AK02-2AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1511-1 PN (6AG1511-1AK02-7AB0)",
+                    "product_id": "109",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1511-1AK02-7AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1511-1 PN (6AG1511-1AK02-7AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1511-1 PN T1 RAIL (6AG2511-1AK01-1AB0)",
+                    "product_id": "110",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG2511-1AK01-1AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1511-1 PN T1 RAIL (6AG2511-1AK01-1AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1511-1 PN T1 RAIL (6AG2511-1AK02-1AB0)",
+                    "product_id": "111",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG2511-1AK02-1AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1511-1 PN T1 RAIL (6AG2511-1AK02-1AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1511-1 PN TX RAIL (6AG2511-1AK01-4AB0)",
+                    "product_id": "112",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG2511-1AK01-4AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1511-1 PN TX RAIL (6AG2511-1AK01-4AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1511-1 PN TX RAIL (6AG2511-1AK02-4AB0)",
+                    "product_id": "113",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG2511-1AK02-4AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1511-1 PN TX RAIL (6AG2511-1AK02-4AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1511F-1 PN (6AG1511-1FK01-2AB0)",
+                    "product_id": "114",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1511-1FK01-2AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1511F-1 PN (6AG1511-1FK01-2AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1511F-1 PN (6AG1511-1FK02-2AB0)",
+                    "product_id": "115",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1511-1FK02-2AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1511F-1 PN (6AG1511-1FK02-2AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1513-1 PN (6AG1513-1AL01-2AB0)",
+                    "product_id": "116",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1513-1AL01-2AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1513-1 PN (6AG1513-1AL01-2AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1513-1 PN (6AG1513-1AL01-7AB0)",
+                    "product_id": "117",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1513-1AL01-7AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1513-1 PN (6AG1513-1AL01-7AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1513-1 PN (6AG1513-1AL02-2AB0)",
+                    "product_id": "118",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1513-1AL02-2AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1513-1 PN (6AG1513-1AL02-2AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1513-1 PN (6AG1513-1AL02-7AB0)",
+                    "product_id": "119",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1513-1AL02-7AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1513-1 PN (6AG1513-1AL02-7AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1513F-1 PN (6AG1513-1FL01-2AB0)",
+                    "product_id": "120",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1513-1FL01-2AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1513F-1 PN (6AG1513-1FL01-2AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1513F-1 PN (6AG1513-1FL02-2AB0)",
+                    "product_id": "121",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1513-1FL02-2AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1513F-1 PN (6AG1513-1FL02-2AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1515F-2 PN (6AG1515-2FM01-2AB0)",
+                    "product_id": "122",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1515-2FM01-2AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1515F-2 PN (6AG1515-2FM01-2AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1515F-2 PN (6AG1515-2FM02-2AB0)",
+                    "product_id": "123",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1515-2FM02-2AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1515F-2 PN (6AG1515-2FM02-2AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1515F-2 PN RAIL (6AG2515-2FM02-4AB0)",
+                    "product_id": "124",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG2515-2FM02-4AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1515F-2 PN RAIL (6AG2515-2FM02-4AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1515F-2 PN T2 RAIL (6AG2515-2FM01-2AB0)",
+                    "product_id": "125",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG2515-2FM01-2AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1515F-2 PN T2 RAIL (6AG2515-2FM01-2AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1516-3 PN/DP (6AG1516-3AN01-2AB0)",
+                    "product_id": "126",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1516-3AN01-2AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1516-3 PN/DP (6AG1516-3AN01-2AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1516-3 PN/DP (6AG1516-3AN01-7AB0)",
+                    "product_id": "127",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1516-3AN01-7AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1516-3 PN/DP (6AG1516-3AN01-7AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1516-3 PN/DP (6AG1516-3AN02-2AB0)",
+                    "product_id": "128",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1516-3AN02-2AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1516-3 PN/DP (6AG1516-3AN02-2AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1516-3 PN/DP (6AG1516-3AN02-7AB0)",
+                    "product_id": "129",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1516-3AN02-7AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1516-3 PN/DP (6AG1516-3AN02-7AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1516-3 PN/DP RAIL (6AG2516-3AN02-4AB0)",
+                    "product_id": "130",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG2516-3AN02-4AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1516-3 PN/DP RAIL (6AG2516-3AN02-4AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1516-3 PN/DP TX RAIL (6AG2516-3AN01-4AB0)",
+                    "product_id": "131",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG2516-3AN01-4AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1516-3 PN/DP TX RAIL (6AG2516-3AN01-4AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1516F-3 PN/DP (6AG1516-3FN01-2AB0)",
+                    "product_id": "132",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1516-3FN01-2AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1516F-3 PN/DP (6AG1516-3FN01-2AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1516F-3 PN/DP (6AG1516-3FN02-2AB0)",
+                    "product_id": "133",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1516-3FN02-2AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1516F-3 PN/DP (6AG1516-3FN02-2AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1516F-3 PN/DP RAIL (6AG2516-3FN02-2AB0)",
+                    "product_id": "134",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG2516-3FN02-2AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1516F-3 PN/DP RAIL (6AG2516-3FN02-2AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/*",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1516F-3 PN/DP RAIL (6AG2516-3FN02-4AB0)",
+                    "product_id": "135",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG2516-3FN02-4AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1516F-3 PN/DP RAIL (6AG2516-3FN02-4AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1518-4 PN/DP (6AG1518-4AP00-4AB0)",
+                    "product_id": "136",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1518-4AP00-4AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1518-4 PN/DP (6AG1518-4AP00-4AB0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1518-4 PN/DP MFP (6AG1518-4AX00-4AC0)",
+                    "product_id": "137",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1518-4AX00-4AC0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1518-4 PN/DP MFP (6AG1518-4AX00-4AC0)"
+            },
+            {
+              "branches": [
+                {
+                  "category": "product_version_range",
+                  "name": "vers:all/<V3.1.4",
+                  "product": {
+                    "name": "SIPLUS S7-1500 CPU 1518F-4 PN/DP (6AG1518-4FP00-4AB0)",
+                    "product_id": "138",
+                    "product_identification_helper": {
+                      "model_numbers": [
+                        "6AG1518-4FP00-4AB0"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "category": "product_name",
+              "name": "SIPLUS S7-1500 CPU 1518F-4 PN/DP (6AG1518-4FP00-4AB0)"
+            }
+          ],
+          "category": "vendor",
+          "name": "Siemens"
+        }
+      ]
+    },
+    "vulnerabilities": [
+      {
+        "cve": "CVE-2024-46887",
+        "cwe": {
+          "id": "CWE-288",
+          "name": "Authentication Bypass Using an Alternate Path or Channel"
+        },
+        "notes": [
+          {
+            "category": "summary",
+            "text": "The web server of affected devices do not properly authenticate user request to the '/ClientArea/RuntimeInfoData.mwsl' endpoint. This could allow an unauthenticated remote attacker to gain knowledge about current actual and configured maximum cycle times as well as about configured maximum communication load.",
+            "title": "Summary"
+          }
+        ],
+        "product_status": {
+          "known_affected": [
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24",
+            "25",
+            "26",
+            "27",
+            "28",
+            "29",
+            "30",
+            "31",
+            "32",
+            "33",
+            "34",
+            "35",
+            "36",
+            "37",
+            "38",
+            "39",
+            "40",
+            "41",
+            "42",
+            "43",
+            "44",
+            "45",
+            "46",
+            "47",
+            "48",
+            "49",
+            "50",
+            "51",
+            "52",
+            "53",
+            "54",
+            "55",
+            "56",
+            "57",
+            "58",
+            "59",
+            "60",
+            "61",
+            "62",
+            "63",
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71",
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78",
+            "79",
+            "80",
+            "81",
+            "82",
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89",
+            "90",
+            "91",
+            "92",
+            "93",
+            "94",
+            "95",
+            "96",
+            "97",
+            "98",
+            "99",
+            "100",
+            "101",
+            "102",
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108",
+            "109",
+            "110",
+            "111",
+            "112",
+            "113",
+            "114",
+            "115",
+            "116",
+            "117",
+            "118",
+            "119",
+            "120",
+            "121",
+            "122",
+            "123",
+            "124",
+            "125",
+            "126",
+            "127",
+            "128",
+            "129",
+            "130",
+            "131",
+            "132",
+            "133",
+            "134",
+            "135",
+            "136",
+            "137",
+            "138"
+          ]
+        },
+        "remediations": [
+          {
+            "category": "none_available",
+            "details": "Currently no fix is available",
+            "product_ids": [
+              "3",
+              "5",
+              "7",
+              "9",
+              "16",
+              "17",
+              "19",
+              "20",
+              "22",
+              "23",
+              "25",
+              "27",
+              "29",
+              "30",
+              "32",
+              "33",
+              "35",
+              "36",
+              "40",
+              "41",
+              "43",
+              "44",
+              "46",
+              "48",
+              "50",
+              "51",
+              "53",
+              "54",
+              "73",
+              "74",
+              "75",
+              "76",
+              "77",
+              "78",
+              "79",
+              "81",
+              "83",
+              "87",
+              "89",
+              "90",
+              "92",
+              "93",
+              "94",
+              "95",
+              "96",
+              "97",
+              "98",
+              "99",
+              "100",
+              "101",
+              "102",
+              "103",
+              "104",
+              "105",
+              "106",
+              "107",
+              "108",
+              "109",
+              "110",
+              "111",
+              "112",
+              "113",
+              "114",
+              "115",
+              "116",
+              "117",
+              "118",
+              "119",
+              "120",
+              "121",
+              "122",
+              "123",
+              "124",
+              "125",
+              "126",
+              "127",
+              "128",
+              "129",
+              "130",
+              "131",
+              "132",
+              "133",
+              "134",
+              "135"
+            ]
+          },
+          {
+            "category": "vendor_fix",
+            "details": "Update to V3.1.4 or later version",
+            "product_ids": [
+              "4",
+              "6",
+              "8",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "18",
+              "21",
+              "24",
+              "26",
+              "28",
+              "31",
+              "34",
+              "37",
+              "38",
+              "39",
+              "42",
+              "45",
+              "47",
+              "49",
+              "52",
+              "55",
+              "56",
+              "57",
+              "58",
+              "59",
+              "60",
+              "61",
+              "62",
+              "63",
+              "64",
+              "65",
+              "66",
+              "67",
+              "68",
+              "69",
+              "70",
+              "71",
+              "72",
+              "136",
+              "137",
+              "138"
+            ]
+          },
+          {
+            "category": "vendor_fix",
+            "details": "Update to V3.1.4 or later version",
+            "product_ids": [
+              "1",
+              "2"
+            ]
+          },
+          {
+            "category": "vendor_fix",
+            "details": "Update to V31.1.4 or later version",
+            "product_ids": [
+              "15"
+            ]
+          },
+          {
+            "category": "vendor_fix",
+            "details": "Update to V31.1.4 or later version",
+            "product_ids": [
+              "80",
+              "82",
+              "84",
+              "85",
+              "86",
+              "88"
+            ]
+          },
+          {
+            "category": "vendor_fix",
+            "details": "Update to V7.0 or later version",
+            "product_ids": [
+              "91"
+            ],
+            "url": "https://support.industry.siemens.com/cs/ww/en/view/109963863/"
+          }
+        ],
+        "scores": [
+          {
+            "cvss_v3": {
+              "baseScore": 5.3,
+              "baseSeverity": "MEDIUM",
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N/E:P/RL:O/RC:C",
+              "version": "3.1"
+            },
+            "products": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19",
+              "20",
+              "21",
+              "22",
+              "23",
+              "24",
+              "25",
+              "26",
+              "27",
+              "28",
+              "29",
+              "30",
+              "31",
+              "32",
+              "33",
+              "34",
+              "35",
+              "36",
+              "37",
+              "38",
+              "39",
+              "40",
+              "41",
+              "42",
+              "43",
+              "44",
+              "45",
+              "46",
+              "47",
+              "48",
+              "49",
+              "50",
+              "51",
+              "52",
+              "53",
+              "54",
+              "55",
+              "56",
+              "57",
+              "58",
+              "59",
+              "60",
+              "61",
+              "62",
+              "63",
+              "64",
+              "65",
+              "66",
+              "67",
+              "68",
+              "69",
+              "70",
+              "71",
+              "72",
+              "73",
+              "74",
+              "75",
+              "76",
+              "77",
+              "78",
+              "79",
+              "80",
+              "81",
+              "82",
+              "83",
+              "84",
+              "85",
+              "86",
+              "87",
+              "88",
+              "89",
+              "90",
+              "91",
+              "92",
+              "93",
+              "94",
+              "95",
+              "96",
+              "97",
+              "98",
+              "99",
+              "100",
+              "101",
+              "102",
+              "103",
+              "104",
+              "105",
+              "106",
+              "107",
+              "108",
+              "109",
+              "110",
+              "111",
+              "112",
+              "113",
+              "114",
+              "115",
+              "116",
+              "117",
+              "118",
+              "119",
+              "120",
+              "121",
+              "122",
+              "123",
+              "124",
+              "125",
+              "126",
+              "127",
+              "128",
+              "129",
+              "130",
+              "131",
+              "132",
+              "133",
+              "134",
+              "135",
+              "136",
+              "137",
+              "138"
+            ]
+          }
+        ],
+        "title": "CVE-2024-46887"
+      }
+    ]
+  }


### PR DESCRIPTION
Currently the deserialization of the document fails if CVSS v3 can't be parsed. This can happen if the CVSS vector string is malformed or parsing library can't properly handle the value (like temporal scores for CVSS v3).
Instead of failing, we should store the original vector string and the score, so that the user can get the original values and handle them as needed. This will also allow us to to have the original CVSS vector strings in the output for versions currently not supported by the CVSS library and enable future support for CVSS v4 in CSAF more easily.